### PR TITLE
Added CORS support

### DIFF
--- a/src/main/java/com/porterhead/filter/CrossOriginResourceSharingFilter.java
+++ b/src/main/java/com/porterhead/filter/CrossOriginResourceSharingFilter.java
@@ -1,0 +1,23 @@
+/*
+ * This filter provides CORS support allowing resources to be requested from other domains
+ * This is important if your client and your server do not reside on the same server or are running on different ports
+ */
+package com.porterhead.filter;
+
+import com.sun.jersey.spi.container.ContainerRequest;
+import com.sun.jersey.spi.container.ContainerResponse;
+import com.sun.jersey.spi.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class CrossOriginResourceSharingFilter implements ContainerResponseFilter {
+
+    @Override
+    public ContainerResponse filter(ContainerRequest request, ContainerResponse response) {
+        response.getHttpHeaders().putSingle("Access-Control-Allow-Origin", "*");
+        response.getHttpHeaders().putSingle("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE");
+        response.getHttpHeaders().putSingle("Access-Control-Allow-Headers", "X-HTTP-Method-Override,Content-Type");
+        return response;
+    }
+
+}


### PR DESCRIPTION
Added CORS support through a filter to allow resources to be requested from other domains. This is important if your client and your server do not reside on the same server or are running on different ports. 
Please note that filter is not being called for some reason but it has to do with how you've configured your project. If you can take a look at it and see why it's not being called. Otherwise it's very straightforward.
